### PR TITLE
Create person registry attach sibling modal

### DIFF
--- a/lib/views/screens/crs/constants/constants.dart
+++ b/lib/views/screens/crs/constants/constants.dart
@@ -2,3 +2,37 @@ const pleaseSelect = "Please Select";
 const pleaseSpecify = "Please specify: ";
 const smallSpacing = 8.0;
 const mediumSpacing = 20.0;
+
+List<String> childClass = [
+  "Please Select",
+  "NOT IN SCHOOL",
+  "ECDE - Baby Class",
+  "ECDE - Middle Class",
+  "ECDE - Pre-Unit Class",
+  "Primary - Class 1",
+  "Primary - Class 2",
+  "Primary - Class 3",
+  "Primary - Class 4",
+  "Primary - Class 5",
+  "Primary - Class 6",
+  "Primary - Class 7",
+  "Primary - Class 8",
+  "Secondary - Form 1",
+  "Secondary - Form 2",
+  "Secondary - Form 3",
+  "Secondary - Form 4",
+  "Secondary - Form 5",
+  "Secondary - Form 6",
+  "University - Year 1",
+  "University - Year 2",
+  "University - Year 3",
+  "University - Year 4",
+  "University - Year 5",
+  "University - Year 6",
+  "Tertiary/Vocational - Year 1",
+  "Tertiary/Vocational - Year 2",
+  "Tertiary/Vocational - Year 3",
+  "Tertiary/Vocational - Year 4",
+  "Tertiary/Vocational - Year 5",
+  "Unknown"
+];

--- a/lib/views/screens/crs/widgets/modals/person_registry_attach_caregiver.dart
+++ b/lib/views/screens/crs/widgets/modals/person_registry_attach_caregiver.dart
@@ -1,0 +1,99 @@
+import 'package:cpims_dcs_mobile/views/screens/crs/widgets/case_data_perpetrators_modal.dart';
+import 'package:cpims_dcs_mobile/views/screens/crs/widgets/form_page_heading.dart';
+import 'package:cpims_dcs_mobile/views/widgets/custom_dropdown.dart';
+import 'package:cpims_dcs_mobile/views/widgets/custom_text_field.dart';
+import 'package:flutter/material.dart';
+
+class PersonRegistryAttachCareGiver extends StatefulWidget {
+  const PersonRegistryAttachCareGiver({super.key});
+
+  @override
+  State<PersonRegistryAttachCareGiver> createState() =>
+      _PersonRegistryAttachCareGiverState();
+}
+
+class _PersonRegistryAttachCareGiverState
+    extends State<PersonRegistryAttachCareGiver> {
+  bool _isChecked = false;
+  List<String> childRelationship = [
+    "None",
+    "Adoptive Father",
+    "Adoptive Mother",
+    "Foster Father",
+    "Foster Mother",
+    "Other Relative",
+    "Parent (Father)",
+    "Parent (Mother)",
+    "Guardian",
+    "Next of Kin",
+    "Other"
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: ListView(
+        padding: const EdgeInsets.all(20.0),
+        children: [
+          const Padding(padding: EdgeInsets.only(top: 20.0)),
+          const FormPageHeading(
+            heading: "Attach Caregiver",
+            hasClosePage: true,
+          ),
+          Row(
+            children: [
+              h2Text("CPIMS registered caregiver"),
+              Checkbox(
+                value: _isChecked,
+                onChanged: (bool? value) {
+                  setState(() {
+                    _isChecked = value ?? false; // Update the state
+                  });
+                },
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          h2Text("Search Caregiver"),
+          const CustomTextField(hintText: 'Caregiver - 5646'),
+          const SizedBox(height: 10),
+          h2Text("First Name"),
+          const CustomTextField(hintText: 'First Name'),
+          const SizedBox(height: 15),
+          h2Text("Surname"),
+          const CustomTextField(hintText: 'Surname'),
+          const SizedBox(height: 15),
+          h2Text("Other Name(s)"),
+          const CustomTextField(hintText: 'Other Names'),
+          const SizedBox(height: 15),
+          h2Text("Date of Birth"),
+          const CustomTextField(hintText: 'Date of Birth'),
+          const SizedBox(height: 15),
+          h2Text("Sex"),
+          CustomDropdown(
+            initialValue: "Please Select",
+            items: const ["Please Select", "Male", "Female"],
+            onChanged: (val) {
+              setState(() {});
+            },
+          ),
+          const SizedBox(height: 15),
+          h2Text("Relationship with Child"),
+          CustomDropdown(
+            initialValue: "None",
+            items: childRelationship,
+            onChanged: (val) {
+              setState(() {});
+            },
+          ),
+          const SizedBox(height: 15),
+          h2Text("National ID No"),
+          const CustomTextField(hintText: 'National ID'),
+          const SizedBox(height: 15),
+          h2Text("MobileNumber:"),
+          const CustomTextField(hintText: 'Cellphone Number'),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/views/screens/crs/widgets/modals/person_registry_attach_child.dart
+++ b/lib/views/screens/crs/widgets/modals/person_registry_attach_child.dart
@@ -1,0 +1,78 @@
+import 'package:cpims_dcs_mobile/views/screens/crs/constants/constants.dart';
+import 'package:cpims_dcs_mobile/views/screens/crs/widgets/case_data_perpetrators_modal.dart';
+import 'package:cpims_dcs_mobile/views/screens/crs/widgets/form_page_heading.dart';
+import 'package:cpims_dcs_mobile/views/widgets/custom_dropdown.dart';
+import 'package:cpims_dcs_mobile/views/widgets/custom_text_field.dart';
+import 'package:flutter/material.dart';
+
+class PersonRegistryAttachSiblingModal extends StatefulWidget {
+  const PersonRegistryAttachSiblingModal({super.key});
+
+  @override
+  State<PersonRegistryAttachSiblingModal> createState() =>
+      _PersonRegistryAttachSiblingModalState();
+}
+
+class _PersonRegistryAttachSiblingModalState
+    extends State<PersonRegistryAttachSiblingModal> {
+  bool _isChecked = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: ListView(padding: const EdgeInsets.all(20.0), children: [
+        const Padding(padding: EdgeInsets.only(top: 20.0)),
+        const FormPageHeading(
+          heading: "Add Sibling",
+          hasClosePage: true,
+        ),
+        Row(
+          children: [
+            h2Text("CPIMS registered caregiver"),
+            Checkbox(
+              value: _isChecked,
+              onChanged: (bool? value) {
+                setState(() {
+                  _isChecked = value ?? false; // Update the state
+                });
+              },
+            ),
+          ],
+        ),
+        const SizedBox(height: 10),
+        h2Text("First Name"),
+        const CustomTextField(hintText: 'First Name'),
+        const SizedBox(height: 15),
+        h2Text("Surname"),
+        const CustomTextField(hintText: 'Surname'),
+        const SizedBox(height: 15),
+        h2Text("Other Name(s)"),
+        const CustomTextField(hintText: 'Other Names'),
+        const SizedBox(height: 15),
+        h2Text("Date of Birth"),
+        const CustomTextField(hintText: 'Date of Birth'),
+        const SizedBox(height: 15),
+        h2Text("Sex"),
+        CustomDropdown(
+          initialValue: "Please Select",
+          items: const ["Please Select", "Male", "Female"],
+          onChanged: (val) {
+            setState(() {});
+          },
+        ),
+        const SizedBox(height: 15),
+        h2Text("Class"),
+        CustomDropdown(
+          initialValue: "Please Select",
+          items: childClass,
+          onChanged: (val) {
+            setState(() {});
+          },
+        ),
+        const SizedBox(height: 15),
+        h2Text("Remarks"),
+        const CustomTextField(maxLines: 4)
+      ]),
+    );
+  }
+}


### PR DESCRIPTION
This pull request adds a new modal component called `PersonRegistryAttachSiblingModal` to the codebase. This modal allows users to add a sibling to a person's registry. The modal includes fields for entering the sibling's first name, surname, other names, date of birth, sex, class, and remarks. It also includes a checkbox for indicating whether the sibling is a CPIMS registered caregiver.