### PR TITLE
Add registry caregiver and sibling models

### DIFF
--- a/lib/models/registry/registry_caregiver_model.dart
+++ b/lib/models/registry/registry_caregiver_model.dart
@@ -34,24 +34,22 @@ class RegistryCaregiverModel {
       'relationshipToChild': relationshipToChild,
       'nationalIdNumber': nationalIdNumber,
       'phoneNumber': phoneNumber,
-      'isRegistered': isRegistered ? 'true' : 'false',
+      'isRegistered': isRegistered ? true : false,
     };
   }
 
-  factory RegistryCaregiverModel.fromJson(Map<String, String> json) {
+  factory RegistryCaregiverModel.fromJson(Map<String, dynamic> json) {
     return RegistryCaregiverModel(
-      id: json['id'] ?? "",
-      firstName: json['firstName'] ?? "",
-      surName: json['surName'] ?? "",
-      otherNames: json['otherNames'] ?? "",
-      dateOfBirth: json['dateOfBirth'] != null
-          ? DateTime.parse(json['dateOfBirth']!)
-          : DateTime.now(),
-      sex: json['sex'] ?? "",
-      relationshipToChild: json['relationshipToChild'] ?? "",
-      nationalIdNumber: json['nationalIdNumber'] ?? "",
-      phoneNumber: json['phoneNumber'] ?? "",
-      isRegistered: json['isRegistered'] == 'true',
+      id: json['id'],
+      firstName: json['firstName'],
+      surName: json['surName'],
+      otherNames: json['otherNames'],
+      dateOfBirth: json['dateOfBirth'],
+      sex: json['sex'],
+      relationshipToChild: json['relationshipToChild'],
+      nationalIdNumber: json['nationalIdNumber'],
+      phoneNumber: json['phoneNumber'],
+      isRegistered: json['isRegistered'] == true,
     );
   }
 }

--- a/lib/models/registry/registry_caregiver_model.dart
+++ b/lib/models/registry/registry_caregiver_model.dart
@@ -38,17 +38,19 @@ class RegistryCaregiverModel {
     };
   }
 
-  factory RegistryCaregiverModel.fromJson(Map<String, dynamic> json) {
+  factory RegistryCaregiverModel.fromJson(Map<String, String> json) {
     return RegistryCaregiverModel(
-      id: json['id'],
-      firstName: json['firstName'],
-      surName: json['surName'],
-      otherNames: json['otherNames'],
-      dateOfBirth: json['dateOfBirth'],
-      sex: json['sex'],
-      relationshipToChild: json['relationshipToChild'],
-      nationalIdNumber: json['nationalIdNumber'],
-      phoneNumber: json['phoneNumber'],
+      id: json['id'] ?? "",
+      firstName: json['firstName'] ?? "",
+      surName: json['surName'] ?? "",
+      otherNames: json['otherNames'] ?? "",
+      dateOfBirth: json['dateOfBirth'] != null
+          ? DateTime.parse(json['dateOfBirth']!)
+          : DateTime.now(),
+      sex: json['sex'] ?? "",
+      relationshipToChild: json['relationshipToChild'] ?? "",
+      nationalIdNumber: json['nationalIdNumber'] ?? "",
+      phoneNumber: json['phoneNumber'] ?? "",
       isRegistered: json['isRegistered'] == 'true',
     );
   }

--- a/lib/models/registry/registry_caregiver_model.dart
+++ b/lib/models/registry/registry_caregiver_model.dart
@@ -1,0 +1,55 @@
+class RegistryCaregiverModel {
+  String id;
+  String firstName;
+  String surName;
+  String otherNames;
+  DateTime dateOfBirth;
+  String sex;
+  String relationshipToChild;
+  String nationalIdNumber;
+  String phoneNumber;
+  bool isRegistered;
+
+  RegistryCaregiverModel({
+    required this.id,
+    required this.firstName,
+    required this.surName,
+    required this.otherNames,
+    required this.dateOfBirth,
+    required this.sex,
+    required this.relationshipToChild,
+    required this.nationalIdNumber,
+    required this.phoneNumber,
+    this.isRegistered = false,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'firstName': firstName,
+      'surName': surName,
+      'otherNames': otherNames,
+      'dateOfBirth': dateOfBirth,
+      'sex': sex,
+      'relationshipToChild': relationshipToChild,
+      'nationalIdNumber': nationalIdNumber,
+      'phoneNumber': phoneNumber,
+      'isRegistered': isRegistered ? 'true' : 'false',
+    };
+  }
+
+  factory RegistryCaregiverModel.fromJson(Map<String, dynamic> json) {
+    return RegistryCaregiverModel(
+      id: json['id'],
+      firstName: json['firstName'],
+      surName: json['surName'],
+      otherNames: json['otherNames'],
+      dateOfBirth: json['dateOfBirth'],
+      sex: json['sex'],
+      relationshipToChild: json['relationshipToChild'],
+      nationalIdNumber: json['nationalIdNumber'],
+      phoneNumber: json['phoneNumber'],
+      isRegistered: json['isRegistered'] == 'true',
+    );
+  }
+}

--- a/lib/models/registry/registry_contact_details_model.dart
+++ b/lib/models/registry/registry_contact_details_model.dart
@@ -22,12 +22,12 @@ class RegistryContactDetailsModel {
   }
 
   // Creates a RegistryContactDetailsModel instance from a map (e.g. decoded JSON)
-  factory RegistryContactDetailsModel.fromJson(Map<String, String> json) {
+  factory RegistryContactDetailsModel.fromJson(Map<String, dynamic> json) {
     return RegistryContactDetailsModel(
-      designatedPhoneNumber: json['designatedPhoneNumber'] ?? "",
-      otherMobileNumber: json['otherMobileNumber'] ?? "",
-      emailAddress: json['emailAddress'] ?? "",
-      physicalLocation: json['physicalLocation'] ?? "",
+      designatedPhoneNumber: json['designatedPhoneNumber'],
+      otherMobileNumber: json['otherMobileNumber'],
+      emailAddress: json['emailAddress'],
+      physicalLocation: json['physicalLocation'],
     );
   }
 }

--- a/lib/models/registry/registry_contact_details_model.dart
+++ b/lib/models/registry/registry_contact_details_model.dart
@@ -22,12 +22,12 @@ class RegistryContactDetailsModel {
   }
 
   // Creates a RegistryContactDetailsModel instance from a map (e.g. decoded JSON)
-  factory RegistryContactDetailsModel.fromJson(Map<String, dynamic> json) {
+  factory RegistryContactDetailsModel.fromJson(Map<String, String> json) {
     return RegistryContactDetailsModel(
-      designatedPhoneNumber: json['designatedPhoneNumber'],
-      otherMobileNumber: json['otherMobileNumber'],
-      emailAddress: json['emailAddress'],
-      physicalLocation: json['physicalLocation'],
+      designatedPhoneNumber: json['designatedPhoneNumber'] ?? "",
+      otherMobileNumber: json['otherMobileNumber'] ?? "",
+      emailAddress: json['emailAddress'] ?? "",
+      physicalLocation: json['physicalLocation'] ?? "",
     );
   }
 }

--- a/lib/models/registry/registry_sibling_model.dart
+++ b/lib/models/registry/registry_sibling_model.dart
@@ -1,0 +1,43 @@
+class RegistrySiblingModel {
+  String firstName;
+  String surName;
+  String otherNames;
+  DateTime dateOfBirth;
+  String sex;
+  String currentClass;
+  String remarks;
+
+  RegistrySiblingModel({
+    required this.firstName,
+    required this.surName,
+    required this.otherNames,
+    required this.dateOfBirth,
+    required this.sex,
+    required this.currentClass,
+    required this.remarks,
+  });
+
+  Map<String, dynamic> toJson() {
+    return {
+      'firstName': firstName,
+      'surName': surName,
+      'otherNames': otherNames,
+      'dateOfBirth': dateOfBirth,
+      'sex': sex,
+      'currentClass': currentClass,
+      'remarks': remarks,
+    };
+  }
+
+  factory RegistrySiblingModel.fromJson(Map<String, dynamic> json) {
+    return RegistrySiblingModel(
+      firstName: json['firstName'],
+      surName: json['surName'],
+      otherNames: json['otherNames'],
+      dateOfBirth: json['dateOfBirth'],
+      sex: json['sex'],
+      currentClass: json['currentClass'],
+      remarks: json['remarks'],
+    );
+  }
+}


### PR DESCRIPTION
This pull request adds two new models: `RegistryCaregiverModel` and `RegistrySiblingModel`. These models are used to represent caregivers and siblings in the registry. They include properties such as name, date of birth, sex, and other relevant information. The models also provide methods for converting to and from JSON. This addition will enable the application to store and retrieve caregiver and sibling data more efficiently.